### PR TITLE
use WP to determine wp-content path

### DIFF
--- a/onelogin-saml-sso/php/settings.php
+++ b/onelogin-saml-sso/php/settings.php
@@ -57,7 +57,7 @@ if (empty($requested_authncontext_values)) {
     }
 }
 
-$acs_endpoint = get_site_url() . (get_option('onelogin_saml_alternative_acs', false) ? '/wp-content/plugins/onelogin-saml-sso/alternative_acs.php' : '/wp-login.php?saml_acs');
+$acs_endpoint = get_site_url() . (get_option('onelogin_saml_alternative_acs', false) ? plugins_url( 'alternative_acs.php', dirname( __FILE__ ) ) : '/wp-login.php?saml_acs');
 
 $settings = array (
 


### PR DESCRIPTION
there's no guarantee that wp-content will be off the root directory or that it will even be named `wp-content` or that the path to the plugins directory even sits inside `wp-content`. Better to use WordPress's built-in functions to determine the correct path.