### PR TITLE
Allow wp-login.php query variables to be filtered

### DIFF
--- a/onelogin-saml-sso/onelogin_saml.php
+++ b/onelogin-saml-sso/onelogin_saml.php
@@ -39,7 +39,7 @@ if ($prevent_reset_password) {
 $action = isset($_REQUEST['action']) ? $_REQUEST['action'] : 'login';
 
 // Handle SLO
-if (isset($_COOKIE['saml_login']) && get_option('onelogin_saml_slo')) { 
+if (isset($_COOKIE['saml_login']) && get_option('onelogin_saml_slo')) {
 	add_action('init', 'saml_slo', 1);
 }
 
@@ -48,7 +48,8 @@ if (isset($_GET['saml_sso'])) {
 	add_action('init', 'saml_sso', 1);
 } else {
 	$execute_sso = false;
-	$saml_actions = isset($_GET['saml_metadata']) || (strpos($_SERVER['SCRIPT_NAME'], 'alternative_acs.php') !== FALSE);
+	$saml_metadata = apply_filters( 'onelogin_saml_metadata', 'saml_metadata' );
+	$saml_actions = isset($_GET[ $saml_metadata ]) || (strpos($_SERVER['SCRIPT_NAME'], 'alternative_acs.php') !== FALSE);
 
 	$wp_login_page = (strpos($_SERVER['SCRIPT_NAME'], 'wp-login.php') !== FALSE) && $action == 'login' && !isset($_GET['loggedout']);
 
@@ -69,7 +70,7 @@ if (isset($_GET['saml_sso'])) {
 	} else if ($local_wp_actions) {
 		$prevent_local_login = get_option('onelogin_saml_customize_action_prevent_local_login', false);
 
-		if (($want_to_local_login && $prevent_local_login) || ($want_to_reset && $prevent_reset_password)) {		
+		if (($want_to_local_login && $prevent_local_login) || ($want_to_reset && $prevent_reset_password)) {
 			$execute_sso = True;
 		}
 	}

--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -14,6 +14,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 	function onelogin_saml_configuration_render() {
 		$title = __("SSO/SAML Settings", 'onelogin-saml-sso');
 		$saml_metadata = apply_filters( 'onelogin_saml_metadata', 'saml_metadata' );
+		$saml_validate_config = apply_filters( 'onelogin_saml_validate_config', 'saml_validate_config' );
 		?>
 			<div class="wrap">
 				<?php screen_icon(); ?>
@@ -22,7 +23,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 				</div>
 				<div class="alignright">
 					<a href="<?php echo get_site_url( null, '/wp-login.php?' . $saml_metadata ); ?>" target="blank"><?php echo __("Go to the metadata of this SP", 'onelogin-saml-sso');?></a><br>
-					<a href="<?php echo get_site_url().'/wp-login.php?saml_validate_config'; ?>" target="blank"><?php echo __("Once configured, validate here your OneLogin SSO/SAML Settings", 'onelogin-saml-sso');?></a>
+					<a href="<?php echo get_site_url( null, '/wp-login.php?' . $saml_validate_config ); ?>" target="blank"><?php echo __("Once configured, validate here your OneLogin SSO/SAML Settings", 'onelogin-saml-sso');?></a>
 				</div>
 				<div style="clear:both"></div>
 				<h2><?php echo esc_html( $title ); ?></h2>

--- a/onelogin-saml-sso/php/configuration.php
+++ b/onelogin-saml-sso/php/configuration.php
@@ -13,6 +13,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 
 	function onelogin_saml_configuration_render() {
 		$title = __("SSO/SAML Settings", 'onelogin-saml-sso');
+		$saml_metadata = apply_filters( 'onelogin_saml_metadata', 'saml_metadata' );
 		?>
 			<div class="wrap">
 				<?php screen_icon(); ?>
@@ -20,7 +21,7 @@ require_once (dirname(__FILE__) . "/extlib/xmlseclibs/xmlseclibs.php");
 					<a href="http://www.onelogin.com"><img src="<?php echo plugins_url('onelogin.png', dirname(__FILE__));?>"></a>
 				</div>
 				<div class="alignright">
-					<a href="<?php echo get_site_url().'/wp-login.php?saml_metadata'; ?>" target="blank"><?php echo __("Go to the metadata of this SP", 'onelogin-saml-sso');?></a><br>
+					<a href="<?php echo get_site_url( null, '/wp-login.php?' . $saml_metadata ); ?>" target="blank"><?php echo __("Go to the metadata of this SP", 'onelogin-saml-sso');?></a><br>
 					<a href="<?php echo get_site_url().'/wp-login.php?saml_validate_config'; ?>" target="blank"><?php echo __("Once configured, validate here your OneLogin SSO/SAML Settings", 'onelogin-saml-sso');?></a>
 				</div>
 				<div style="clear:both"></div>

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -10,7 +10,11 @@ require_once "compatibility.php";
 
 
 function saml_checker() {
-	if (isset($_GET['saml_acs'])) {
+	/**
+	 * Allow saml_acs URL query variable to be customized.
+	 */
+	$saml_acs = apply_filters( 'onelogin_saml_acs', 'saml_acs' );
+	if ( isset( $_GET[ $saml_acs ] ) ) {
 		saml_acs();
 	}
 	else if (isset($_GET['saml_sls'])) {

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -11,9 +11,13 @@ require_once "compatibility.php";
 
 function saml_checker() {
 	/**
-	 * Allow saml_acs URL query variable to be customized.
+	 * Allow saml_acs query variables to be customized.
 	 */
-	$saml_acs = apply_filters( 'onelogin_saml_acs', 'saml_acs' );
+	$saml_acs             = apply_filters( 'onelogin_saml_acs', 'saml_acs' );
+	$saml_sls             = apply_filters( 'onelogin_saml_sls', 'saml_sls' );
+	$saml_metadata        = apply_filters( 'onelogin_saml_metadata', 'saml_metadata' );
+	$saml_validate_config = apply_filters( 'onelogin_saml_validate_config', 'saml_validate_config' );
+
 	if ( isset( $_GET[ $saml_acs ] ) ) {
 		saml_acs();
 	}

--- a/onelogin-saml-sso/php/functions.php
+++ b/onelogin-saml-sso/php/functions.php
@@ -21,11 +21,11 @@ function saml_checker() {
 	if ( isset( $_GET[ $saml_acs ] ) ) {
 		saml_acs();
 	}
-	else if (isset($_GET['saml_sls'])) {
+	else if (isset($_GET[ $saml_sls ])) {
 		saml_sls();
-	} else if (isset($_GET['saml_metadata'])) {
+	} else if (isset($_GET[ $saml_metadata ])) {
 		saml_metadata();
-	} else if (isset($_GET['saml_validate_config'])) {
+	} else if (isset($_GET[ $saml_validate_config ])) {
 		saml_validate_config();
 	}
 }

--- a/onelogin-saml-sso/php/settings.php
+++ b/onelogin-saml-sso/php/settings.php
@@ -61,6 +61,7 @@ if (empty($requested_authncontext_values)) {
  * Allow saml_acs URL query variable to be customized.
  */
 $saml_acs = apply_filters( 'onelogin_saml_acs', 'saml_acs' );
+$saml_sls = apply_filters( 'onelogin_saml_acs', 'saml_sls' );
 $acs_endpoint = get_option( 'onelogin_saml_alternative_acs', false ) ? plugins_url( 'alternative_acs.php', dirname( __FILE__ ) ) : wp_login_url() . '?' . $saml_acs;
 
 $settings = array (
@@ -74,7 +75,7 @@ $settings = array (
             'url' => $acs_endpoint
         ),
         'singleLogoutService' => array (
-            'url' => get_site_url().'/wp-login.php?saml_sls'
+            'url' => get_site_url( null, '/wp-login.php?' . $saml_sls )
         ),
         'NameIDFormat' => $opt['NameIDFormat'],
         'x509cert' => get_option('onelogin_saml_advanced_settings_sp_x509cert'),

--- a/onelogin-saml-sso/php/settings.php
+++ b/onelogin-saml-sso/php/settings.php
@@ -57,7 +57,11 @@ if (empty($requested_authncontext_values)) {
     }
 }
 
-$acs_endpoint = get_option('onelogin_saml_alternative_acs', false) ? plugins_url( 'alternative_acs.php', dirname( __FILE__ ) ) : wp_login_url() . '?saml_acs';
+/**
+ * Allow saml_acs URL query variable to be customized.
+ */
+$saml_acs = apply_filters( 'onelogin_saml_acs', 'saml_acs' );
+$acs_endpoint = get_option( 'onelogin_saml_alternative_acs', false ) ? plugins_url( 'alternative_acs.php', dirname( __FILE__ ) ) : wp_login_url() . '?' . $saml_acs;
 
 $settings = array (
 


### PR DESCRIPTION
We have a situation where we need to use unique urls for things that are currently hard-coded as query variables (specifically the assertion URL and the XML metadata urls, but the same could apply to any of the URL query variables).

This PR adds filters to each of the url query variables where they are being used so additional developers can customize the query variables (say to distinguish between dev/prod environments, which is our scenario).

Also tweaked usage of get_site_url where it was being used (specifically with reference to wp-login.php with these query variables applied) to pass the relative path to the actual get_site_url function.

================================

Discussion on base plugin here: https://github.com/onelogin/wordpress-saml/pull/35